### PR TITLE
Escape % in message and values

### DIFF
--- a/formatters/kv.go
+++ b/formatters/kv.go
@@ -19,9 +19,18 @@ func KVEntryString(entry *logrus.Entry) string {
 		keys = append(keys, k)
 	}
 
+	// Escape % if it appears in value, so Sprintf doesn't try to expand it
+	entry.Message = strings.Replace(entry.Message, "%", "%%", -1)
+
 	strentry := fmt.Sprintf("MESSAGE='%s'", entry.Message)
 	for _, k := range keys {
 		v := entry.Data[k]
+		// Escape % if it appears in value, so Sprintf doesn't try to expand it
+		s, ok := v.(string)
+		if ok {
+			s = strings.Replace(s, "%", "%%", -1)
+			v = s
+		}
 		strentry = fmt.Sprintf("%s %s='%+v'", strentry, strings.ToUpper(k), v)
 	}
 

--- a/formatters/kv.go
+++ b/formatters/kv.go
@@ -19,22 +19,21 @@ func KVEntryString(entry *logrus.Entry) string {
 		keys = append(keys, k)
 	}
 
-	// Escape % if it appears in value, so Sprintf doesn't try to expand it
-	entry.Message = strings.Replace(entry.Message, "%", "%%", -1)
-
-	strentry := fmt.Sprintf("MESSAGE='%s'", entry.Message)
+	strentry := "MESSAGE=" + singleQuoteString(entry.Message)
 	for _, k := range keys {
 		v := entry.Data[k]
-		// Escape % if it appears in value, so Sprintf doesn't try to expand it
 		s, ok := v.(string)
 		if ok {
-			s = strings.Replace(s, "%", "%%", -1)
 			v = s
 		}
-		strentry = fmt.Sprintf("%s %s='%+v'", strentry, strings.ToUpper(k), v)
+		strentry = strentry + " " + strings.ToUpper(k) + "=" + singleQuoteString(s)
 	}
 
 	return strentry
+}
+
+func singleQuoteString(s string) string {
+	return "'" + strings.Replace(s, "'", "\\'", -1) + "'"
 }
 
 // Format - See logrus.Formatter.Format for docs

--- a/formatters/kv_test.go
+++ b/formatters/kv_test.go
@@ -1,0 +1,84 @@
+package formatters
+
+import (
+	"testing"
+
+	"github.com/behance/go-logrus"
+)
+
+func TestKVEntryStringEmpty(t *testing.T) {
+	entry := &logrus.Entry{}
+	s := KVEntryString(entry)
+	expected := "MESSAGE=''"
+	if s != expected {
+		t.Errorf("s was %+v; not equal to expected value: %+v", s, expected)
+	}
+}
+
+func TestKVEntryStringSimple(t *testing.T) {
+	entry := &logrus.Entry{Message: "Hello"}
+	s := KVEntryString(entry)
+	expected := "MESSAGE='Hello'"
+	if s != expected {
+		t.Errorf("s was %+v; not equal to expected value: %+v", s, expected)
+	}
+}
+
+func TestKVEntryStringData(t *testing.T) {
+	entry := &logrus.Entry{
+		Message: "Hello",
+		Data:    map[string]interface{}{"foo": "bar"},
+	}
+	s := KVEntryString(entry)
+	expected := "MESSAGE='Hello' FOO='bar'"
+	if s != expected {
+		t.Errorf("s was %+v; not equal to expected value: %+v", s, expected)
+	}
+}
+
+func TestKVEntryStringSingleQuoteInData(t *testing.T) {
+	entry := &logrus.Entry{
+		Message: "Hello",
+		Data: map[string]interface{}{
+			"status": "It's all good",
+		},
+	}
+	s := KVEntryString(entry)
+	expected := "MESSAGE='Hello' STATUS='It\\'s all good'"
+	if s != expected {
+		t.Errorf("s was %+v; not equal to expected value: %+v", s, expected)
+	}
+}
+
+func TestKVEntryStringSingleQuoteInMessage(t *testing.T) {
+	entry := &logrus.Entry{Message: "Hello, it's me"}
+	s := KVEntryString(entry)
+	expected := "MESSAGE='Hello, it\\'s me'"
+	if s != expected {
+		t.Errorf("s was %+v; not equal to expected value: %+v", s, expected)
+	}
+}
+
+func TestKVEntryStringPercentInData(t *testing.T) {
+	entry := &logrus.Entry{
+		Message: "Hello",
+		Data: map[string]interface{}{
+			"path":   "%2Fpath%2Fto%2Ffile",
+			"effort": "110%",
+		},
+	}
+	s := KVEntryString(entry)
+	expected := "MESSAGE='Hello' PATH='%2Fpath%2Fto%2Ffile' EFFORT='110%'"
+	if s != expected {
+		t.Errorf("s was %+v; not equal to expected value: %+v", s, expected)
+	}
+}
+
+func TestKVEntryStringPercentInMessage(t *testing.T) {
+	entry := &logrus.Entry{Message: "Test coverage is 100%!"}
+	s := KVEntryString(entry)
+	expected := "MESSAGE='Test coverage is 100%!'"
+	if s != expected {
+		t.Errorf("s was %+v; not equal to expected value: %+v", s, expected)
+	}
+}


### PR DESCRIPTION
Before:

```
... URL='http://192.168.223.128:8083/api/v1/networkpolicies/mattapp%!F(MISSING)mattimage'
```

After:

```
... URL='http://192.168.223.128:8083/api/v1/networkpolicies/mattapp%2Fmattimage'
```

Fixes: https://github.com/adobe-community/issues-ethos/issues/4284

Cc: @iderdik, @jimmyislive